### PR TITLE
Make docker container run unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,14 @@ RUN make linux
 
 
 FROM alpine:3.12
-
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+ARG UNAME="server-status"
+ARG GNAME="server-status"
+ARG UID=1000
+ARG GID=1000
 WORKDIR /server-status
 COPY --from=0 /go/src/github.com/mgerb/ServerStatus/dist/ServerStatus-linux .
 ENTRYPOINT ./ServerStatus-linux
+RUN addgroup -g ${GID} "${GNAME}" && adduser -D -u ${UID} -G "${GNAME}" "${UNAME}" &&\
+    chown "${UNAME}":"${GNAME}" -R /server-status/ &&\
+    apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+USER ${UNAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,9 @@ version: "3"
 services:
   server-status:
     image: mgerb/server-status:latest
+    build:
+      args:
+        UID: 1000
+        GID: 1000
     volumes:
     - ./config.json:/server-status/config.json


### PR DESCRIPTION
This makes the docker container user not run as root and instead run as a user with the defined UID and GID.

This should improve security for those who use the docker daemon as it protects the host from container breakouts, as the compromised user would likely not have access to anything sensitive on the host.

The only downside with this is that it adds the restriction that the person mapping the config.json needs to ensure that the file can be read by the container user too, but the default UMASK already allows all users to read a file, so I do not think this is really a problem unless the person alters their config.json permission bits to not allow some people to read it.