### PR TITLE
Fix outdated / broken bot

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/bwmarrin/discordgo"
-  version = "0.20.0"
+  version = "0.24.0"
 
 [prune]
   go-tests = true

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,6 @@ type configStruct struct {
 	Servers         []Server      `json:"Servers"`
 	GameStatus      string        `json:"GameStatus"`
 	PollingInterval time.Duration `json:"PollingInterval"`
-	BotPrefix       string        `json:"BotPrefix"`
 }
 
 type Server struct {

--- a/main.go
+++ b/main.go
@@ -22,13 +22,13 @@ func main() {
 	bot.Connect(config.Config.Token)
 
 	// add handlers
-	bot.AddHandler(serverstatus.MessageHandler)
+    bot.AddHandler(serverstatus.InteractionHandler)
 
 	//start websocket to listen for messages
 	bot.Start()
 
 	//start server status task
-	serverstatus.Start()
+    serverstatus.Start()
 
 	// Simple way to keep program running until CTRL-C is pressed.
 	<-make(chan struct{})


### PR DESCRIPTION
I noticed the current bot starts with a strange websocket error and stays offline, never having its MessageHandler get called. I upgraded discordgo from 0.20 to 0.24.0 which fixes those issues.

The command prefix and MessageHandling have also been replaced with Discord's newer Application Command and IntegrationHandling. I wasn't able to figure out a way to show an error to the user if the bot doesn't have the `applications.commands` scope, so the command just won't work in that case.